### PR TITLE
Fix level display format to show "Novice Lv1" style

### DIFF
--- a/Home.html
+++ b/Home.html
@@ -9037,7 +9037,8 @@ async function fetchAndDisplayPosts() {
                         currentLevel = Math.max(1, currentLevel);
                         const info = getLevelInfo(currentLevel);
                         if (levelChipIcon) levelChipIcon.className = `${info.icon}`;
-                        levelChipName.textContent = info.name;
+                        const baseName = (info.name || '').replace(/\s+Lv\.?\s*\d+/i, '').trim();
+                        levelChipName.textContent = `${baseName} Lv${currentLevel}`;
                         const gasNeededCurr = getTotalGasRequiredToReachLevel(currentLevel);
                         const gasNeededNext = getTotalGasRequiredToReachLevel(currentLevel + 1);
                         const segSize = Math.max(1, gasNeededNext - gasNeededCurr);


### PR DESCRIPTION
## Purpose
The user wanted to standardize the level progress bar display in home.html to match the format used in profile.html and levels.html. Specifically, they wanted the level names to appear as "Novice Lv1", "Intermediate Lv2", etc., instead of just showing the raw level name from the data.

## Code changes
- Modified the level chip name display logic in Home.html
- Added string processing to extract the base level name (removing existing "Lv" suffixes)
- Implemented consistent formatting to display levels as "{baseName} Lv{currentLevel}" format
- This ensures the home page level section now displays levels consistently with the established pattern across other pages

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 26`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fc72ca3b2cd747ac86f84b3545d80aff/pulse-field)

👀 [Preview Link](https://fc72ca3b2cd747ac86f84b3545d80aff-pulse-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fc72ca3b2cd747ac86f84b3545d80aff</projectId>-->
<!--<branchName>pulse-field</branchName>-->