### PR TITLE
Remove Buy JCoins button and hide dashboard sections

### DIFF
--- a/Wallet.html
+++ b/Wallet.html
@@ -1134,26 +1134,12 @@
         <div class="fiat-note">100 JCoins ≈</div>
         <div class="fiat-value" id="oneJcoinRateDisplay">—</div>
     </div>
-    <div class="fiat-col">
-        <a href="/Developer.html" class="fiat-value" style="text-decoration:none;display:inline-flex;align-items:center;gap:8px" title="Buy JCoins from Developer">
-            <i class="fas fa-store"></i>
-            <span>Buy JCoins</span>
-        </a>
-    </div>
 </div>
-                <div class="balance-actions">
-                    <button class="balance-btn" id="sendBtn">
-                        <i class="fas fa-arrow-up"></i> Send
-                    </button>
-                    <button class="balance-btn" id="receiveBtn">
-                        <i class="fas fa-arrow-down"></i> Receive
-                    </button>
-                </div>
             </div>
         </section>
 
         <!-- Quick Stats -->
-        <section class="stats-grid">
+        <section class="stats-grid" style="display: none;">
             <div class="stat-card">
                 <div class="stat-icon income">
                     <i class="fas fa-arrow-down"></i>
@@ -1178,7 +1164,7 @@
         </section>
 
         <!-- Actions Section -->
-        <section class="actions-section">
+        <section class="actions-section" style="display: none;">
             <h2 class="section-title">Quick Actions</h2>
             <div class="action-grid">
                 <button class="action-btn" id="sendJCoinsBtn">
@@ -1614,7 +1600,7 @@
         </section>
 
         <!-- Transactions Section -->
-        <section class="transactions-section">
+        <section class="transactions-section" style="display: none;">
             <div class="transactions-header">
                 <h2 class="section-title">Recent Transactions</h2>
                 <div class="transactions-controls">


### PR DESCRIPTION
## Purpose
Simplify the wallet dashboard by removing the "Buy JCoins" functionality and hiding unnecessary sections. The user requested to keep only the essential elements: user balance and JCoin conversion rate display, removing all other interactive features to create a cleaner, more focused interface.

## Code changes
- Removed the "Buy JCoins" button and link to Developer.html from the fiat conversion section
- Removed the balance action buttons (Send/Receive) 
- Hidden the Quick Stats section using `display: none`
- Hidden the Quick Actions section using `display: none`
- Hidden the Recent Transactions section using `display: none`
- Preserved the user balance display and JCoin conversion rate functionalityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 35`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f620ad360c314144951ed4b2d1290438/glow-studio)

👀 [Preview Link](https://f620ad360c314144951ed4b2d1290438-glow-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f620ad360c314144951ed4b2d1290438</projectId>-->
<!--<branchName>glow-studio</branchName>-->