### PR TITLE
Add multi-currency support for JCoin display

### DIFF
--- a/Wallet.html
+++ b/Wallet.html
@@ -1762,7 +1762,14 @@ let userCurrency = { code: 'USD', symbol: '$', label: 'USD' };
                 if (noteEl) noteEl.textContent = '1 JCoin =';
 
                 const oneEl = document.getElementById('oneJcoinRateDisplay');
-                if (oneEl) oneEl.textContent = `₦${ngnPerJcoin.toFixed(2)} NGN`;
+                if (oneEl) {
+                  if ((userCurrency.code || 'USD') === 'NGN') {
+                    oneEl.textContent = `₦${ngnPerJcoin.toFixed(2)} NGN`;
+                  } else {
+                    const oneLocal = ngnPerJcoin * fxRateNGNToLocal;
+                    oneEl.textContent = formatLocalCurrency(oneLocal);
+                  }
+                }
 
                 const localEl = document.getElementById('localValueDisplay');
                 if (localEl) {

--- a/currency.js
+++ b/currency.js
@@ -1,15 +1,34 @@
 export let userCountryCode = null;
 export let userCurrency = { code: 'USD', symbol: '$', label: 'USD' };
 
+const COUNTRY_TO_CURRENCY = {
+  US: 'USD', CA: 'CAD', MX: 'MXN', BR: 'BRL', AR: 'ARS', CO: 'COP', CL: 'CLP', PE: 'PEN',
+  GB: 'GBP', IE: 'EUR', FR: 'EUR', DE: 'EUR', ES: 'EUR', IT: 'EUR', PT: 'EUR', NL: 'EUR', BE: 'EUR', AT: 'EUR', FI: 'EUR', GR: 'EUR', LU: 'EUR', MT: 'EUR', CY: 'EUR', SK: 'EUR', SI: 'EUR', EE: 'EUR', LV: 'EUR', LT: 'EUR',
+  CH: 'CHF', SE: 'SEK', NO: 'NOK', DK: 'DKK', PL: 'PLN', CZ: 'CZK', HU: 'HUF', RO: 'RON', BG: 'BGN', TR: 'TRY', UA: 'UAH', RU: 'RUB',
+  AU: 'AUD', NZ: 'NZD', JP: 'JPY', CN: 'CNY', HK: 'HKD', SG: 'SGD', KR: 'KRW', IN: 'INR', ID: 'IDR', TH: 'THB', MY: 'MYR', PH: 'PHP', VN: 'VND',
+  NG: 'NGN', ZA: 'ZAR', KE: 'KES', GH: 'GHS', EG: 'EGP', MA: 'MAD', DZ: 'DZD', TN: 'TND', ET: 'ETB', UG: 'UGX', TZ: 'TZS', CM: 'XAF', SN: 'XOF', CI: 'XOF', BF: 'XOF', BJ: 'XOF', NE: 'XOF', ML: 'XOF', TG: 'XOF', GW: 'XOF', GN: 'GNF',
+  AE: 'AED', SA: 'SAR', QA: 'QAR', KW: 'KWD', BH: 'BHD', OM: 'OMR', IL: 'ILS'
+};
+
+const CURRENCY_SYMBOL = {
+  USD: '$', EUR: '€', GBP: '£', NGN: '₦', CAD: 'CA$', AUD: 'A$', NZD: 'NZ$', JPY: '¥', CNY: '¥', HKD: 'HK$', SGD: 'S$', KRW: '₩', INR: '₹', IDR: 'Rp', THB: '฿', MYR: 'RM', PHP: '₱', VND: '₫',
+  CHF: 'CHF', SEK: 'kr', NOK: 'kr', DKK: 'kr', PLN: 'zł', CZK: 'Kč', HUF: 'Ft', RON: 'lei', BGN: 'лв', TRY: '₺', UAH: '₴', RUB: '₽',
+  ZAR: 'R', KES: 'KSh', GHS: '₵', EGP: 'E£', MAD: 'MAD', DZD: 'د.ج', TND: 'د.ت', ETB: 'Br', UGX: 'USh', TZS: 'TSh', XAF: 'FCFA', XOF: 'CFA', GNF: 'FG',
+  AED: 'د.إ', SAR: 'ر.س', QAR: 'ر.ق', KWD: 'د.ك', BHD: 'ب.د', OMR: 'ر.ع', ILS: '₪', MXN: 'MX$', BRL: 'R$', ARS: '$', COP: 'COL$', CLP: 'CLP$', PEN: 'S/'
+};
+
 export function inferCountryCodeFromProfileOrLocale(profile) {
   try {
     const pref = localStorage.getItem('jchat-currency-preference');
     if (pref && pref !== 'AUTO') {
-      return pref === 'NGN' ? 'NG' : null;
+      if (pref.length === 3) return null; // currency override handled elsewhere
+      return pref.toUpperCase();
     }
-    const raw = (profile?.country || '').toString().trim().toLowerCase();
+    const raw = (profile?.country || '').toString().trim();
     if (raw) {
-      if (raw === 'ng' || raw === 'ngn' || raw === 'nigeria' || raw.includes('nigeria')) return 'NG';
+      const r = raw.toUpperCase();
+      if (COUNTRY_TO_CURRENCY[r]) return r;
+      if (r.includes('NIGERIA') || r === 'NG' || r === 'NGN') return 'NG';
     }
     const lang = navigator.language || navigator.userLanguage || '';
     const match = lang.match(/-([A-Z]{2})$/);
@@ -19,8 +38,9 @@ export function inferCountryCodeFromProfileOrLocale(profile) {
 }
 
 export function resolveCurrencyForCountry(countryCode) {
-  if (countryCode === 'NG') return { code: 'NGN', symbol: '₦', label: 'NGN' };
-  return { code: 'USD', symbol: '$', label: 'USD' };
+  const code = COUNTRY_TO_CURRENCY[(countryCode || '').toUpperCase()] || 'USD';
+  const symbol = CURRENCY_SYMBOL[code] || code;
+  return { code, symbol, label: code };
 }
 
 export function setUserCurrencyFromProfile(profile) {
@@ -40,7 +60,6 @@ export function formatLocalCurrency(amount) {
 
 export function applyCurrencyDisplayForWallet(jcoinPackagesGrid) {
   const amountLabel = document.querySelector('label[for="nairaInput"]');
-  // Always show manual receipt section
   const manualBuySection = document.querySelector('.manual-buy-section');
   if (manualBuySection) manualBuySection.style.display = '';
 


### PR DESCRIPTION
## Purpose

The user wanted to implement multi-currency support for displaying JCoin values to accommodate a global user base. Instead of only showing JCoin values in Nigerian Naira (NGN), the system now detects the user's location/currency and displays JCoin values in their local currency using real-time exchange rates.

## Code changes

- **Enhanced currency detection**: Added comprehensive country-to-currency mapping (`COUNTRY_TO_CURRENCY`) covering major regions including Americas, Europe, Asia-Pacific, Africa, and Middle East
- **Currency symbol mapping**: Added `CURRENCY_SYMBOL` object with proper symbols for all supported currencies (₦, $, €, £, ¥, etc.)
- **Improved country inference**: Enhanced `inferCountryCodeFromProfileOrLocale()` to handle currency preferences and better country code detection
- **Dynamic currency resolution**: Updated `resolveCurrencyForCountry()` to use the new mappings instead of hardcoded NGN/USD logic
- **Conditional JCoin display**: Modified wallet display logic to show JCoin rates in user's local currency when not NGN, while maintaining NGN as the base for Nigerian users
- **Code cleanup**: Removed redundant comments and improved code structureTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 38`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f620ad360c314144951ed4b2d1290438/stellar-haven)

👀 [Preview Link](https://f620ad360c314144951ed4b2d1290438-stellar-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f620ad360c314144951ed4b2d1290438</projectId>-->
<!--<branchName>stellar-haven</branchName>-->