### PR TITLE
Fix daily reward claim and customize inspiration buttons

### DIFF
--- a/Home.html
+++ b/Home.html
@@ -3812,7 +3812,7 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
                     </button>
                     <button id="customizeInspirationButton" class="inspiration-action-button" aria-label="Customize Inspiration Type" data-bound="1" disabled=""><i class="fas fa-cog"></i> Customize Inspiration </button>
                     <!-- NEW: Daily Bonus Button -->
-                    <button id="claimDailyBonusButton" class="inspiration-action-button" aria-label="Claim Daily Bonus" data-bound="1" disabled=""><span class="button-text">Login to Claim Bonus</span></button>
+                    <button id="claimDailyBonusButton" class="inspiration-action-button" aria-label="Claim Daily Bonus" disabled=""><span class="button-text">Login to Claim Bonus</span></button>
                             </div>
             
             <!-- Share Inspiration Modal -->

--- a/Home.html
+++ b/Home.html
@@ -10567,6 +10567,7 @@ async function fetchAndDisplayPosts() {
 
             // Ensure inspiration section listeners are attached after elements exist
             attachInspirationEventListeners();
+            if (!inspirationIntervalId) startInspirationDisplay(currentUserProfileData?.inspirationType || 'motivational');
 
             updateStreakAndQuestsUI();
             fetchStories();

--- a/Home.html
+++ b/Home.html
@@ -3810,7 +3810,7 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
                     <button id="sharePostInspirationButton" class="inspiration-action-button" disabled aria-label="Share Inspiration as Post">
                         <i class="fas fa-share-alt"></i> Share / Post
                     </button>
-                    <button id="customizeInspirationButton" class="inspiration-action-button" aria-label="Customize Inspiration Type" data-bound="1" disabled=""><i class="fas fa-cog"></i> Customize Inspiration </button>
+                    <button id="customizeInspirationButton" class="inspiration-action-button" aria-label="Customize Inspiration Type" disabled=""><i class="fas fa-cog"></i> Customize Inspiration </button>
                     <!-- NEW: Daily Bonus Button -->
                     <button id="claimDailyBonusButton" class="inspiration-action-button" aria-label="Claim Daily Bonus" disabled=""><span class="button-text">Login to Claim Bonus</span></button>
                             </div>


### PR DESCRIPTION
## Purpose
Based on the conversation history, users identified that the daily reward claim feature was not working properly and needed to be fixed for logged-in users. Additionally, the customize inspiration feature needed to be made functional, with a request to have inspirations appear every minute.

## Code changes
- **Removed `data-bound="1"` attribute** from both the customize inspiration button and daily bonus claim button to fix their functionality
- **Added automatic inspiration display initialization** with `startInspirationDisplay()` call to ensure inspirations appear regularly based on user's inspiration type preference
- **Maintained disabled state** for buttons while fixing their underlying binding issues

These changes address the button functionality issues and implement the requested automatic inspiration display feature.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 44`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f7be45f5f39f4454bd1451a4333b6835/pixel-haven)

👀 [Preview Link](https://f7be45f5f39f4454bd1451a4333b6835-pixel-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f7be45f5f39f4454bd1451a4333b6835</projectId>-->
<!--<branchName>pixel-haven</branchName>-->